### PR TITLE
Исправление ошибки с NOT фильтром

### DIFF
--- a/app/src/main/java/com/yoshione/fingen/filters/AmountFilter.java
+++ b/app/src/main/java/com/yoshione/fingen/filters/AmountFilter.java
@@ -124,7 +124,7 @@ public class AmountFilter extends AbstractFilter implements Parcelable {
                     condition = String.format("(%s) OR (%s)", transferIncome, transferExpense);
                 break;
         }
-        if (mInverted) {
+        if (mInverted && !condition.isEmpty()) {
             condition = String.format("NOT(%s)", condition);
         }
 


### PR DESCRIPTION
при установке NOT фильтра, в результате которого не сгенерится SQL код, в итоговый запрос будет добавлена под строка AND NOT - с пустым фильтром.

В итоге будет выполнена попытка не корректного SQL запроса, приложение крашится сразу при попытке открыть транзакции (с сохраненым ранее фильтром)