### PR TITLE
Usage dropbox api key from keystore.properties files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,6 +44,7 @@ android {
         android.defaultConfig.resValue "string", "oAuthWebClientID", keystoreProperties["oAuthWebClientID"]
         android.defaultConfig.resValue "string", "inAppLicenseKey", keystoreProperties["inAppLicenseKey"]
         android.defaultConfig.resValue "string", "inAppLicenseSalt", keystoreProperties["inAppLicenseSalt"]
+        android.defaultConfig.resValue "string", "dropboxApiKey", keystoreProperties["dropboxApiKey"]
         android.defaultConfig.manifestPlaceholders = [
                 dropboxApiKey: keystoreProperties["dropboxApiKey"],
                 mapsApiKey   : keystoreProperties["mapsApiKey"]
@@ -55,6 +56,7 @@ android {
     } else {
         android.defaultConfig.resValue "string", "inAppLicenseKey", ""
         android.defaultConfig.resValue "string", "inAppLicenseSalt", ""
+        android.defaultConfig.resValue "string", "dropboxApiKey", ""
         android.defaultConfig.manifestPlaceholders = [
                 dropboxApiKey: "",
                 mapsApiKey   : ""
@@ -127,7 +129,7 @@ dependencies {
     implementation 'com.github.gabrielemariotti.changeloglib:changelog:2.1.0'
     implementation 'com.github.hotchemi:permissionsdispatcher:3.1.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v2.2.5'
-    implementation 'com.github.QuadFlask:colorpicker:0.0.13'
+    implementation 'com.github.QuadFlask:colorpicker:0.0.14'
     implementation 'com.l4digital.fastscroll:fastscroll:1.0.4'
     implementation 'com.mikepenz:actionitembadge:3.3.2@aar'
     implementation 'com.sothree.slidinguppanel:library:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -258,7 +258,7 @@
             android:configChanges="orientation|keyboard"
             android:launchMode="singleTask">
             <intent-filter>
-                <data android:scheme="${dropboxApiKey}"/>
+                <data android:scheme="db-${dropboxApiKey}"/>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/main/java/com/yoshione/fingen/ActivityBackup.java
+++ b/app/src/main/java/com/yoshione/fingen/ActivityBackup.java
@@ -169,11 +169,14 @@ public class ActivityBackup extends ToolbarActivity {
 
     private void initDropbox() {
         getUserAccount();
+        Context context = this.getApplicationContext();
         final SharedPreferences dropboxPrefs = getSharedPreferences("com.yoshione.fingen.dropbox", Context.MODE_PRIVATE);
         final String token = dropboxPrefs.getString("dropbox-token", null);
+        int resId = context.getResources().getIdentifier("dropboxApiKey", "string", context.getPackageName());
+        String dropboxAppKey = context.getString(resId);
         mEditTextDropboxAccount.setOnClickListener(view -> {
             if (token == null) {
-                Auth.startOAuth2Authentication(ActivityBackup.this, getString(R.string.DROPBOX_APP_KEY));
+                Auth.startOAuth2Authentication(ActivityBackup.this, dropboxAppKey);
             }
         });
         mButtonLogoutFromDropbox.setVisibility(token == null ? View.GONE : View.VISIBLE);

--- a/app/src/main/res/values/strings_no_translate.xml
+++ b/app/src/main/res/values/strings_no_translate.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="DROPBOX_APP_KEY" translatable="false">vwkqvsnd67bz8jm</string>
-    <!--<string name="app_name" translatable="false">Fingen</string>-->
     <string name="web_client_id" translatable="false">74268970763-ib3pfrlr833dbs2bcq23oil43qna3q9t.apps.googleusercontent.com</string>
     <string name="ttl_license" translatable="false">Unless required by applicable law or agreed to in writing, this software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.\n\n
     In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law or agreed to in writing, shall the authors of this software be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising out of the use or inability to use the software (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses)</string>


### PR DESCRIPTION
испытывал проблемы с настройкой дропбокса, разобрался почему (ключ указывался в двух местах, в xml и keystore.properties), изменил немного код, для использования айди приложения из одного места
keystore.properties обязательно должен содержать следующие ключи (можно даже пустые, за исключением keystore - он должен указывать на путь к файлу относительно подпапки app):
```
keyAlias=
keyPassword=
storeFile=..\\android.keystore
storePassword=
dropboxApiKey=
mapsApiKey=
fabricApiKey=
inAppLicenseKey=
inAppLicenseSalt=
oAuthWebClientID=
```